### PR TITLE
speed improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,19 @@ function loadImage(url, cb) {
   })
 }
 
+function getPixel(pngReader, x, y) {
+	var i = pngReader.colors * pngReader.bitDepth / 8 * (y * pngReader.width + x);
+	return pngReader.pixels[i+1]
+};
+
 function getCoordinate(x, y, z) {
   x = ~~scale(x, -(worldHeight / 2), (worldHeight / 2), 0, this.width)
+  y = ~~scale(y, -(worldHeight / 2), (worldHeight / 2), 0, worldHeight)
   z = ~~scale(z, -(worldHeight / 2), (worldHeight / 2), 0, this.height)
-  var pixel = this.getPixel(x,z)
-  var r = pixel[1]
-  var height = scale(r, 0, 255, 0, worldHeight/5)
-  if (y<1) return 2
-  return y > height ? 0 : 1
+  var pixel = getPixel(this, x, z)
+  var height = ~~scale(pixel, 0, 255, 0, worldHeight / 5)
+  if (y < 1) return 2
+  return y > height ? 0 : 1 
 }
 
 function scale( x, fromLow, fromHigh, toLow, toHigh ) {


### PR DESCRIPTION
instead of using this function https://github.com/arian/pngjs/blob/master/PNG.js#L139 which is the normal built in one that is slow (because it calls Array.prototype.slice 2 million times for 2 million voxels) I just took out all the cruft and now it is much faster but only works with grayscale PNGs (aka heightmaps)
